### PR TITLE
Rename inventory item db handler

### DIFF
--- a/go/pkg/db/client.go
+++ b/go/pkg/db/client.go
@@ -31,7 +31,7 @@ type client struct {
 	verificationCodeHandle            *verificationCodeHandler
 	pointOfInterestGroupHandle        *pointOfInterestGroupHandle
 	pointOfInterestChallengeHandle    *pointOfInterestChallengeHandle
-	inventoryItemHandle               *inventoryItemHandler
+	ownedInventoryItemHandle          *ownedInventoryItemHandler
 	auditItemHandle                   *auditItemHandler
 	imageGenerationHandle             *imageGenerationHandle
 	pointOfInterestChildrenHandle     *pointOfInterestChildrenHandle
@@ -99,7 +99,7 @@ func NewClient(cfg ClientConfig) (DbClient, error) {
 		verificationCodeHandle:            &verificationCodeHandler{db: db},
 		pointOfInterestGroupHandle:        &pointOfInterestGroupHandle{db: db},
 		pointOfInterestChallengeHandle:    &pointOfInterestChallengeHandle{db: db},
-		inventoryItemHandle:               &inventoryItemHandler{db: db},
+		ownedInventoryItemHandle:          &ownedInventoryItemHandler{db: db},
 		auditItemHandle:                   &auditItemHandler{db: db},
 		imageGenerationHandle:             &imageGenerationHandle{db: db},
 		pointOfInterestChildrenHandle:     &pointOfInterestChildrenHandle{db: db},
@@ -194,8 +194,8 @@ func (c *client) AuditItem() AuditItemHandle {
 	return c.auditItemHandle
 }
 
-func (c *client) InventoryItem() InventoryItemHandle {
-	return c.inventoryItemHandle
+func (c *client) OwnedInventoryItem() OwnedInventoryItemHandle {
+	return c.ownedInventoryItemHandle
 }
 
 func (c *client) PointOfInterestChallenge() PointOfInterestChallengeHandle {

--- a/go/pkg/db/interfaces.go
+++ b/go/pkg/db/interfaces.go
@@ -28,7 +28,7 @@ type DbClient interface {
 	VerificationCode() VerificationCodeHandle
 	PointOfInterestGroup() PointOfInterestGroupHandle
 	PointOfInterestChallenge() PointOfInterestChallengeHandle
-	InventoryItem() InventoryItemHandle
+	OwnedInventoryItem() OwnedInventoryItemHandle
 	AuditItem() AuditItemHandle
 	ImageGeneration() ImageGenerationHandle
 	PointOfInterestChildren() PointOfInterestChildrenHandle
@@ -209,7 +209,7 @@ type PointOfInterestChallengeHandle interface {
 	GetChildrenForChallenge(ctx context.Context, challengeID uuid.UUID) ([]models.PointOfInterestChildren, error)
 }
 
-type InventoryItemHandle interface {
+type OwnedInventoryItemHandle interface {
 	CreateOrIncrementInventoryItem(ctx context.Context, teamID *uuid.UUID, userID *uuid.UUID, inventoryItemID int, quantity int) error
 	UseInventoryItem(ctx context.Context, ownedInventoryItemID uuid.UUID) error
 	ApplyInventoryItem(ctx context.Context, matchID uuid.UUID, inventoryItemID int, teamID uuid.UUID, duration time.Duration) error

--- a/go/pkg/db/owned_inventory_item.go
+++ b/go/pkg/db/owned_inventory_item.go
@@ -10,11 +10,11 @@ import (
 	"gorm.io/gorm"
 )
 
-type inventoryItemHandler struct {
+type ownedInventoryItemHandler struct {
 	db *gorm.DB
 }
 
-func (h *inventoryItemHandler) GetItems(ctx context.Context, userOrTeam models.OwnedInventoryItem) ([]models.OwnedInventoryItem, error) {
+func (h *ownedInventoryItemHandler) GetItems(ctx context.Context, userOrTeam models.OwnedInventoryItem) ([]models.OwnedInventoryItem, error) {
 	var items []models.OwnedInventoryItem
 
 	if userOrTeam.TeamID != nil {
@@ -31,7 +31,7 @@ func (h *inventoryItemHandler) GetItems(ctx context.Context, userOrTeam models.O
 	return items, nil
 }
 
-func (h *inventoryItemHandler) GetUsersItems(ctx context.Context, userID uuid.UUID) ([]models.OwnedInventoryItem, error) {
+func (h *ownedInventoryItemHandler) GetUsersItems(ctx context.Context, userID uuid.UUID) ([]models.OwnedInventoryItem, error) {
 	var items []models.OwnedInventoryItem
 	result := h.db.Where("user_id = ?", userID).Find(&items)
 	if result.Error != nil {
@@ -40,7 +40,7 @@ func (h *inventoryItemHandler) GetUsersItems(ctx context.Context, userID uuid.UU
 	return items, nil
 }
 
-func (h *inventoryItemHandler) StealItems(ctx context.Context, thiefTeamID uuid.UUID, victimTeamID uuid.UUID) error {
+func (h *ownedInventoryItemHandler) StealItems(ctx context.Context, thiefTeamID uuid.UUID, victimTeamID uuid.UUID) error {
 	items, err := h.GetItems(ctx, models.OwnedInventoryItem{TeamID: &victimTeamID})
 	if err != nil {
 		return err
@@ -56,7 +56,7 @@ func (h *inventoryItemHandler) StealItems(ctx context.Context, thiefTeamID uuid.
 	return nil
 }
 
-func (h *inventoryItemHandler) StealItem(ctx context.Context, thiefTeamID uuid.UUID, victimTeamID uuid.UUID, inventoryItemID int) error {
+func (h *ownedInventoryItemHandler) StealItem(ctx context.Context, thiefTeamID uuid.UUID, victimTeamID uuid.UUID, inventoryItemID int) error {
 	items, err := h.GetItems(ctx, models.OwnedInventoryItem{TeamID: &victimTeamID})
 	if err != nil {
 		return err
@@ -74,7 +74,7 @@ func (h *inventoryItemHandler) StealItem(ctx context.Context, thiefTeamID uuid.U
 	return nil
 }
 
-func (h *inventoryItemHandler) FindByID(ctx context.Context, id uuid.UUID) (*models.OwnedInventoryItem, error) {
+func (h *ownedInventoryItemHandler) FindByID(ctx context.Context, id uuid.UUID) (*models.OwnedInventoryItem, error) {
 	var item models.OwnedInventoryItem
 	result := h.db.Where("id = ?", id).First(&item)
 	if result.Error != nil {
@@ -83,7 +83,7 @@ func (h *inventoryItemHandler) FindByID(ctx context.Context, id uuid.UUID) (*mod
 	return &item, nil
 }
 
-func (h *inventoryItemHandler) CreateOrIncrementInventoryItem(ctx context.Context, teamID *uuid.UUID, userID *uuid.UUID, inventoryItemID int, quantity int) error {
+func (h *ownedInventoryItemHandler) CreateOrIncrementInventoryItem(ctx context.Context, teamID *uuid.UUID, userID *uuid.UUID, inventoryItemID int, quantity int) error {
 	var item models.OwnedInventoryItem
 	var query string
 	var queryID *uuid.UUID
@@ -114,7 +114,7 @@ func (h *inventoryItemHandler) CreateOrIncrementInventoryItem(ctx context.Contex
 	return h.db.Save(&item).Error
 }
 
-func (h *inventoryItemHandler) UseInventoryItem(ctx context.Context, ownedInventoryItemID uuid.UUID) error {
+func (h *ownedInventoryItemHandler) UseInventoryItem(ctx context.Context, ownedInventoryItemID uuid.UUID) error {
 	var item models.OwnedInventoryItem
 	result := h.db.Where("id = ?", ownedInventoryItemID).First(&item)
 	if result.Error != nil {
@@ -130,7 +130,7 @@ func (h *inventoryItemHandler) UseInventoryItem(ctx context.Context, ownedInvent
 	return h.db.Save(&item).Error
 }
 
-func (h *inventoryItemHandler) ApplyInventoryItem(ctx context.Context, matchID uuid.UUID, inventoryItemID int, teamID uuid.UUID, duration time.Duration) error {
+func (h *ownedInventoryItemHandler) ApplyInventoryItem(ctx context.Context, matchID uuid.UUID, inventoryItemID int, teamID uuid.UUID, duration time.Duration) error {
 	newEffect := models.MatchInventoryItemEffect{
 		ID:              uuid.New(),
 		MatchID:         matchID,

--- a/go/sonar/internal/quartermaster/client.go
+++ b/go/sonar/internal/quartermaster/client.go
@@ -57,7 +57,7 @@ func (c *client) GetItem(ctx context.Context, teamID *uuid.UUID, userID *uuid.UU
 		return InventoryItem{}, err
 	}
 
-	if err := c.db.InventoryItem().CreateOrIncrementInventoryItem(ctx, teamID, userID, item.ID, 1); err != nil {
+	if err := c.db.OwnedInventoryItem().CreateOrIncrementInventoryItem(ctx, teamID, userID, item.ID, 1); err != nil {
 		return InventoryItem{}, err
 	}
 
@@ -70,7 +70,7 @@ func (c *client) GetItemSpecificItem(ctx context.Context, teamID *uuid.UUID, use
 		return InventoryItem{}, err
 	}
 
-	if err := c.db.InventoryItem().CreateOrIncrementInventoryItem(ctx, teamID, userID, item.ID, 1); err != nil {
+	if err := c.db.OwnedInventoryItem().CreateOrIncrementInventoryItem(ctx, teamID, userID, item.ID, 1); err != nil {
 		return InventoryItem{}, err
 	}
 
@@ -78,12 +78,12 @@ func (c *client) GetItemSpecificItem(ctx context.Context, teamID *uuid.UUID, use
 }
 
 func (c *client) UseItem(ctx context.Context, ownedInventoryItemID uuid.UUID, metadata *UseItemMetadata) error {
-	ownedInventoryItem, err := c.db.InventoryItem().FindByID(ctx, ownedInventoryItemID)
+	ownedInventoryItem, err := c.db.OwnedInventoryItem().FindByID(ctx, ownedInventoryItemID)
 	if err != nil {
 		return err
 	}
 
-	if err := c.db.InventoryItem().UseInventoryItem(ctx, ownedInventoryItem.ID); err != nil {
+	if err := c.db.OwnedInventoryItem().UseInventoryItem(ctx, ownedInventoryItem.ID); err != nil {
 		return err
 	}
 
@@ -132,7 +132,7 @@ func (c *client) getRandomItem() (InventoryItem, error) {
 
 func (c *client) EquipItem(ctx context.Context, userID uuid.UUID, ownedInventoryItemID uuid.UUID) error {
 	// First, get the owned inventory item to determine what it is
-	ownedItem, err := c.db.InventoryItem().FindByID(ctx, ownedInventoryItemID)
+	ownedItem, err := c.db.OwnedInventoryItem().FindByID(ctx, ownedInventoryItemID)
 	if err != nil {
 		return fmt.Errorf("failed to find owned inventory item: %w", err)
 	}

--- a/go/sonar/internal/quartermaster/item_effects.go
+++ b/go/sonar/internal/quartermaster/item_effects.go
@@ -39,20 +39,20 @@ func (q *client) ApplyItemEffectByID(ctx context.Context, ownedInventoryItem mod
 	case 6:
 		if ownedInventoryItem.IsTeamItem() {
 			// Steal all of another team's items. Must be within a 100 meter radius of the target team to use.
-			return q.db.InventoryItem().StealItems(ctx, *ownedInventoryItem.TeamID, metadata.TargetTeamID)
+			return q.db.OwnedInventoryItem().StealItems(ctx, *ownedInventoryItem.TeamID, metadata.TargetTeamID)
 		}
 
 		return nil
 	case 7:
 		// Inflict a wound on another team.
-		return q.db.InventoryItem().CreateOrIncrementInventoryItem(ctx, &metadata.TargetTeamID, nil, 10, 1)
+		return q.db.OwnedInventoryItem().CreateOrIncrementInventoryItem(ctx, &metadata.TargetTeamID, nil, 10, 1)
 	case 8:
 		// Hold in your inventory to increase your score by 1.
 		return nil
 	case 9:
 		if ownedInventoryItem.IsTeamItem() {
 			// Steal an item from another team.
-			items, err := q.db.InventoryItem().GetItems(ctx, models.OwnedInventoryItem{TeamID: &metadata.TargetTeamID})
+			items, err := q.db.OwnedInventoryItem().GetItems(ctx, models.OwnedInventoryItem{TeamID: &metadata.TargetTeamID})
 			if err != nil {
 				return err
 			}
@@ -67,7 +67,7 @@ func (q *client) ApplyItemEffectByID(ctx context.Context, ownedInventoryItem mod
 					break
 				}
 			}
-			return q.db.InventoryItem().StealItem(ctx, *ownedInventoryItem.TeamID, metadata.TargetTeamID, randomItem.InventoryItemID)
+			return q.db.OwnedInventoryItem().StealItem(ctx, *ownedInventoryItem.TeamID, metadata.TargetTeamID, randomItem.InventoryItemID)
 		}
 
 		return nil
@@ -79,14 +79,14 @@ func (q *client) ApplyItemEffectByID(ctx context.Context, ownedInventoryItem mod
 		return nil
 	case 12:
 		// Drink to remove one damage
-		items, err := q.db.InventoryItem().GetItems(ctx, ownedInventoryItem)
+		items, err := q.db.OwnedInventoryItem().GetItems(ctx, ownedInventoryItem)
 		if err != nil {
 			return err
 		}
 
 		for _, item := range items {
 			if item.InventoryItemID == 10 {
-				return q.db.InventoryItem().UseInventoryItem(ctx, item.ID)
+				return q.db.OwnedInventoryItem().UseInventoryItem(ctx, item.ID)
 			}
 		}
 
@@ -96,7 +96,7 @@ func (q *client) ApplyItemEffectByID(ctx context.Context, ownedInventoryItem mod
 		return nil
 	case 14:
 		// Steal all of another team's items.
-		return q.db.InventoryItem().StealItems(ctx, *ownedInventoryItem.TeamID, metadata.TargetTeamID)
+		return q.db.OwnedInventoryItem().StealItems(ctx, *ownedInventoryItem.TeamID, metadata.TargetTeamID)
 	case 15:
 		// Negate up to 3 damage when held.
 		return nil
@@ -110,7 +110,7 @@ func (q *client) AddEffectToMatch(ctx context.Context, matchID uuid.UUID, invent
 		return errors.New("cant use item without a team")
 	}
 
-	return q.db.InventoryItem().ApplyInventoryItem(ctx, matchID, inventoryItem.InventoryItemID, *inventoryItem.TeamID, duration)
+	return q.db.OwnedInventoryItem().ApplyInventoryItem(ctx, matchID, inventoryItem.InventoryItemID, *inventoryItem.TeamID, duration)
 }
 
 func (q *client) captureChallenge(ctx context.Context, ownedInventoryItem models.OwnedInventoryItem, metadata *UseItemMetadata) error {
@@ -128,8 +128,8 @@ func (q *client) captureChallenge(ctx context.Context, ownedInventoryItem models
 		if err != nil {
 			return err
 		}
-		return q.db.InventoryItem().CreateOrIncrementInventoryItem(ctx, ownedInventoryItem.TeamID, ownedInventoryItem.UserID, item.ID, 1)
+		return q.db.OwnedInventoryItem().CreateOrIncrementInventoryItem(ctx, ownedInventoryItem.TeamID, ownedInventoryItem.UserID, item.ID, 1)
 	} else {
-		return q.db.InventoryItem().CreateOrIncrementInventoryItem(ctx, ownedInventoryItem.TeamID, ownedInventoryItem.UserID, challenge.InventoryItemID, 1)
+		return q.db.OwnedInventoryItem().CreateOrIncrementInventoryItem(ctx, ownedInventoryItem.TeamID, ownedInventoryItem.UserID, challenge.InventoryItemID, 1)
 	}
 }

--- a/go/sonar/internal/server/server.go
+++ b/go/sonar/internal/server/server.go
@@ -1190,7 +1190,7 @@ func (s *server) giveItem(ctx *gin.Context) {
 		return
 	}
 
-	if err := s.dbClient.InventoryItem().CreateOrIncrementInventoryItem(
+			if err := s.dbClient.OwnedInventoryItem().CreateOrIncrementInventoryItem(
 		ctx,
 		requestBody.TeamID,
 		requestBody.UserID,
@@ -1306,7 +1306,7 @@ func (s *server) getOwnedInventoryItems(ctx *gin.Context) {
 		}
 	}
 
-	items, err := s.dbClient.InventoryItem().GetItems(ctx, userOrTeam)
+	items, err := s.dbClient.OwnedInventoryItem().GetItems(ctx, userOrTeam)
 	if err != nil {
 		ctx.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
@@ -2020,7 +2020,7 @@ func (s *server) useItem(ctx *gin.Context) {
 		return
 	}
 
-	ownedInventoryItem, err := s.dbClient.InventoryItem().FindByID(ctx, ownedInventoryItemID)
+	ownedInventoryItem, err := s.dbClient.OwnedInventoryItem().FindByID(ctx, ownedInventoryItemID)
 	if err != nil {
 		ctx.JSON(http.StatusInternalServerError, gin.H{
 			"error": err.Error(),
@@ -2091,7 +2091,7 @@ func (s *server) getTeamsInventory(ctx *gin.Context) {
 		return
 	}
 
-	inventory, err := s.dbClient.InventoryItem().GetItems(ctx, models.OwnedInventoryItem{TeamID: &teamID})
+	inventory, err := s.dbClient.OwnedInventoryItem().GetItems(ctx, models.OwnedInventoryItem{TeamID: &teamID})
 	if err != nil {
 		ctx.JSON(http.StatusInternalServerError, gin.H{
 			"error": err.Error(),


### PR DESCRIPTION
Rename `inventory_item` DB handler to `owned_inventory_item` for consistency with model/table names and improved clarity.