### PR TITLE
Fix GM empty-state crashes and make player nav responsive

### DIFF
--- a/go/pkg/db/vampire.go
+++ b/go/pkg/db/vampire.go
@@ -328,7 +328,7 @@ type SubmissionDetail struct {
 }
 
 func (h *vampireHandler) ListSubmissionsDetailed(ctx context.Context, statusFilter string) ([]SubmissionDetail, error) {
-	var details []SubmissionDetail
+	details := []SubmissionDetail{}
 	q := h.db.WithContext(ctx).
 		Table("vampire_mission_submissions s").
 		Select(`s.id, s.player_id, s.mission_id, s.status, s.player_answer,
@@ -529,7 +529,7 @@ type QuizSubmissionDetail struct {
 }
 
 func (h *vampireHandler) ListQuizSubmissionsDetailed(ctx context.Context) ([]QuizSubmissionDetail, error) {
-	var out []QuizSubmissionDetail
+	out := []QuizSubmissionDetail{}
 	if err := h.db.WithContext(ctx).
 		Table("vampire_quiz_submissions s").
 		Select(`s.id, s.player_id, s.question_id, s.answer, s.is_correct, s.locked,

--- a/js/packages/vampire-ascendancy/src/components/PlayerShell.tsx
+++ b/js/packages/vampire-ascendancy/src/components/PlayerShell.tsx
@@ -135,13 +135,14 @@ const TopNav = ({
   active: Tab;
   onSelect: (t: Tab) => void;
 }) => (
-  <nav className="sticky top-0 z-10 -mx-4 px-4 py-2 mb-4 bg-blood-ink/90 backdrop-blur-sm border-b border-blood/30">
-    <div className="flex gap-1 justify-center">
+  <nav className="sticky top-0 z-10 -mx-4 px-2 py-2 mb-4 bg-blood-ink/90 backdrop-blur-sm border-b border-blood/30">
+    {/* Tabs share the width equally and shrink to fit, so the bar never clips. */}
+    <div className="flex gap-1">
       {tabs.map((t) => (
         <button
           key={t}
           onClick={() => onSelect(t)}
-          className={`px-3 py-2 rounded-md text-xs sm:text-sm uppercase tracking-[0.15em] transition-colors ${
+          className={`flex-1 min-w-0 px-1 py-2 rounded-md text-center uppercase tracking-[0.08em] text-[11px] sm:text-sm transition-colors ${
             active === t ? 'bg-blood text-bone' : 'text-bone/80 hover:text-bone'
           }`}
         >

--- a/js/packages/vampire-ascendancy/src/components/QuizTakeover.tsx
+++ b/js/packages/vampire-ascendancy/src/components/QuizTakeover.tsx
@@ -18,7 +18,8 @@ export const QuizTakeover = ({ onDone }: { onDone: () => void }) => {
   useEffect(() => {
     getQuiz(token)
       .then((d) => {
-        setQuestions(d.questions);
+        const qs = d.questions || [];
+        setQuestions(qs);
         // Restore any unsent draft so a reload/blip mid-quiz keeps typed answers.
         let saved: Record<string, string> = {};
         try {
@@ -27,7 +28,7 @@ export const QuizTakeover = ({ onDone }: { onDone: () => void }) => {
           /* ignore */
         }
         const init: Record<string, string> = {};
-        d.questions.forEach((q) => (init[q.id] = saved[q.id] ?? q.answer ?? ''));
+        qs.forEach((q) => (init[q.id] = saved[q.id] ?? q.answer ?? ''));
         setAnswers(init);
         if (d.submitted) setDone(true);
       })

--- a/js/packages/vampire-ascendancy/src/components/gm/QuizSection.tsx
+++ b/js/packages/vampire-ascendancy/src/components/gm/QuizSection.tsx
@@ -14,7 +14,10 @@ export const QuizSection = ({
   const [subs, setSubs] = useState<GMQuizSubmission[]>([]);
   const [busy, setBusy] = useState(false);
 
-  const loadSubs = () => gmListQuizSubmissions().then((d) => setSubs(d.submissions)).catch(() => {});
+  const loadSubs = () =>
+    gmListQuizSubmissions()
+      .then((d) => setSubs(d.submissions || []))
+      .catch(() => {});
   useEffect(() => {
     loadSubs();
     const id = setInterval(loadSubs, 6000);

--- a/js/packages/vampire-ascendancy/src/components/gm/SubmissionsSection.tsx
+++ b/js/packages/vampire-ascendancy/src/components/gm/SubmissionsSection.tsx
@@ -13,7 +13,7 @@ export const SubmissionsSection = () => {
   const load = () => {
     setLoading(true);
     gmListSubmissions(filter)
-      .then((d) => setSubs(d.submissions))
+      .then((d) => setSubs(d.submissions || []))
       .catch(() => {})
       .finally(() => setLoading(false));
   };


### PR DESCRIPTION
- GM submissions/quiz-submissions endpoints return [] instead of null when empty (a nil Go slice serialized to JSON null, crashing .length on the client with "null is not an object")
- Add defensive `|| []` fallbacks on the GM submission/quiz lists and the player quiz so a null response can never crash the UI
- Player top nav tabs now share the bar width via flex-1 and shrink their type on small screens, so the tabs never clip on narrow phones